### PR TITLE
[FEAT] 초기 온보딩 프로필 설정(#14)

### DIFF
--- a/src/main/java/PickitPickit/auth/dto/response/AuthUserResponse.java
+++ b/src/main/java/PickitPickit/auth/dto/response/AuthUserResponse.java
@@ -5,14 +5,16 @@ import PickitPickit.user.domain.User;
 public record AuthUserResponse(
         Long id,
         String nickname,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean onboardingCompleted
 ) {
 
     public static AuthUserResponse from(User user) {
         return new AuthUserResponse(
                 user.getId(),
                 user.getNickname(),
-                user.getProfileImageUrl()
+                user.getProfileImageUrl(),
+                user.isOnboardingCompleted()
         );
     }
 }

--- a/src/main/java/PickitPickit/auth/service/AuthService.java
+++ b/src/main/java/PickitPickit/auth/service/AuthService.java
@@ -74,21 +74,33 @@ public class AuthService {
             throw new ApiException(ErrorStatus.KAKAO_LOGIN_FAILED, "카카오 회원번호를 조회할 수 없습니다.");
         }
 
-        String nickname = kakaoUser.nickname();
-        if (!StringUtils.hasText(nickname)) {
-            throw new ApiException(ErrorStatus.KAKAO_LOGIN_FAILED, "카카오 닉네임 동의가 필요합니다.");
-        }
-
         String kakaoId = String.valueOf(kakaoUser.id());
         String profileImageUrl = kakaoUser.profileImageUrl();
 
         return userRepository.findByKakaoId(kakaoId)
-                .map(user -> updateUserProfile(user, nickname, profileImageUrl))
-                .orElseGet(() -> userRepository.save(User.createFromKakao(kakaoId, nickname, profileImageUrl)));
+                .map(user -> updateKakaoProfileImage(user, profileImageUrl))
+                .orElseGet(() -> userRepository.save(User.createFromKakao(
+                        kakaoId,
+                        createInitialNickname(kakaoUser.nickname(), kakaoId),
+                        profileImageUrl
+                )));
     }
 
-    private User updateUserProfile(User user, String nickname, String profileImageUrl) {
-        user.updateProfile(nickname, profileImageUrl);
+    private User updateKakaoProfileImage(User user, String profileImageUrl) {
+        user.updateKakaoProfileImageUrl(profileImageUrl);
         return user;
+    }
+
+    private String createInitialNickname(String preferredNickname, String kakaoId) {
+        if (StringUtils.hasText(preferredNickname) && !userRepository.existsByNickname(preferredNickname)) {
+            return preferredNickname;
+        }
+
+        String temporaryNickname = "pickit_" + kakaoId;
+        if (!userRepository.existsByNickname(temporaryNickname)) {
+            return temporaryNickname;
+        }
+
+        throw new ApiException(ErrorStatus.DUPLICATE_NICKNAME, "초기 닉네임을 생성할 수 없습니다.");
     }
 }

--- a/src/main/java/PickitPickit/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/PickitPickit/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import PickitPickit.global.response.ErrorStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -63,6 +64,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(es.getStatus())
                 .body(ErrorResponse.of(es.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException e) {
+        log.warn("[MESSAGE-NOT-READABLE] {}", e.getMessage());
+        var es = ErrorStatus.INVALID_INPUT;
+        return ResponseEntity
+                .status(es.getStatus())
+                .body(ErrorResponse.of(es.getCode(), "요청 본문을 확인해주세요."));
     }
 
     /**

--- a/src/main/java/PickitPickit/global/response/ErrorStatus.java
+++ b/src/main/java/PickitPickit/global/response/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus {
     /* 409 CONFLICT */
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "DUPLICATE_RESOURCE", "이미 존재하는 리소스입니다."),
     CONTACT_ALREADY_EXISTS(HttpStatus.CONFLICT, "CONTACT_ALREADY_EXISTS", "이미 관계가 존재합니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
@@ -49,7 +50,15 @@ public enum ErrorStatus {
 
     /* Store / 공공데이터 */
     PUBLIC_API_ERROR(HttpStatus.BAD_GATEWAY, "PUBLIC_API_ERROR", "공공데이터 API 호출에 실패했습니다."),
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_NOT_FOUND", "해당 매장을 찾을 수 없습니다.");
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_NOT_FOUND", "해당 매장을 찾을 수 없습니다."),
+
+    /* Onboarding */
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME", "닉네임은 2자 이상 15자 이하로 입력해주세요."),
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE", "허용되지 않은 프로필 이미지입니다."),
+    INVALID_PROFILE_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "INVALID_PROFILE_IMAGE_TYPE", "허용되지 않은 프로필 이미지 타입입니다."),
+    INTEREST_TAG_REQUIRED(HttpStatus.BAD_REQUEST, "INTEREST_TAG_REQUIRED", "관심 태그를 최소 1개 선택해주세요."),
+    INTEREST_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "INTEREST_TAG_NOT_FOUND", "존재하지 않거나 비활성화된 관심 태그입니다."),
+    ONBOARDING_INCOMPLETE(HttpStatus.BAD_REQUEST, "ONBOARDING_INCOMPLETE", "온보딩 완료 조건을 충족하지 못했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/PickitPickit/global/security/SecurityConfig.java
+++ b/src/main/java/PickitPickit/global/security/SecurityConfig.java
@@ -1,7 +1,12 @@
 package PickitPickit.global.security;
 
+import PickitPickit.global.dto.ErrorResponse;
+import PickitPickit.global.response.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
@@ -32,6 +37,7 @@ public class SecurityConfig {
     private static final String ACCESS_TOKEN_TYPE = "access";
 
     private final JwtProperties jwtProperties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -49,8 +55,15 @@ public class SecurityConfig {
                                 "/api/auth/token/reissue",
                                 "/api/auth/logout"
                         ).permitAll()
+                        .requestMatchers("/api/onboarding/**").authenticated()
                         .requestMatchers("/api/auth/me").authenticated()
                         .anyRequest().permitAll()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) ->
+                                writeError(response, ErrorStatus.UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                writeError(response, ErrorStatus.FORBIDDEN))
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
                 .build();
@@ -104,5 +117,12 @@ public class SecurityConfig {
                 jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8),
                 "HmacSHA256"
         );
+    }
+
+    private void writeError(HttpServletResponse response, ErrorStatus errorStatus) throws java.io.IOException {
+        response.setStatus(errorStatus.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorStatus.getCode(), errorStatus.getMessage()));
     }
 }

--- a/src/main/java/PickitPickit/onboarding/controller/OnboardingController.java
+++ b/src/main/java/PickitPickit/onboarding/controller/OnboardingController.java
@@ -1,0 +1,90 @@
+package PickitPickit.onboarding.controller;
+
+import PickitPickit.global.response.ApiResponse;
+import PickitPickit.global.response.SuccessStatus;
+import PickitPickit.onboarding.dto.request.InterestTagUpdateRequest;
+import PickitPickit.onboarding.dto.request.NicknameUpdateRequest;
+import PickitPickit.onboarding.dto.request.ProfileImageUpdateRequest;
+import PickitPickit.onboarding.dto.response.*;
+import PickitPickit.onboarding.service.OnboardingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Onboarding", description = "초기 프로필 설정 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/onboarding")
+@SecurityRequirement(name = "bearerAuth")
+public class OnboardingController {
+
+    private final OnboardingService onboardingService;
+
+    @Operation(summary = "온보딩 상태 조회", description = "현재 로그인 사용자의 온보딩 상태를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<OnboardingStatusResponse>> getStatus(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return ApiResponse.success(SuccessStatus.FETCHED, onboardingService.getStatus(getUserId(jwt)));
+    }
+
+    @Operation(summary = "닉네임 저장", description = "프론트에서 입력 또는 랜덤 생성한 닉네임을 저장합니다.")
+    @PatchMapping("/nickname")
+    public ResponseEntity<ApiResponse<OnboardingStatusResponse>> updateNickname(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody NicknameUpdateRequest request
+    ) {
+        return ApiResponse.success(SuccessStatus.UPDATED, onboardingService.updateNickname(getUserId(jwt), request));
+    }
+
+    @Operation(summary = "프로필 이미지 후보 조회", description = "카카오 프로필 이미지 URL과 허용된 기본 이미지 URL을 조회합니다.")
+    @GetMapping("/profile-images")
+    public ResponseEntity<ApiResponse<ProfileImageOptionsResponse>> getProfileImages(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return ApiResponse.success(SuccessStatus.FETCHED, onboardingService.getProfileImages(getUserId(jwt)));
+    }
+
+    @Operation(summary = "프로필 이미지 저장", description = "카카오 또는 기본 프로필 이미지 URL을 저장합니다.")
+    @PatchMapping("/profile-image")
+    public ResponseEntity<ApiResponse<OnboardingStatusResponse>> updateProfileImage(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody ProfileImageUpdateRequest request
+    ) {
+        return ApiResponse.success(SuccessStatus.UPDATED, onboardingService.updateProfileImage(getUserId(jwt), request));
+    }
+
+    @Operation(summary = "관심 태그 목록 조회", description = "선택 가능한 관심 태그 목록을 조회합니다.")
+    @GetMapping("/interest-tags")
+    public ResponseEntity<ApiResponse<List<InterestTagResponse>>> getInterestTags() {
+        return ApiResponse.success(SuccessStatus.FETCHED, onboardingService.getInterestTags());
+    }
+
+    @Operation(summary = "관심 태그 저장", description = "사용자가 선택한 관심 태그를 저장합니다.")
+    @PatchMapping("/interest-tags")
+    public ResponseEntity<ApiResponse<OnboardingStatusResponse>> updateInterestTags(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody InterestTagUpdateRequest request
+    ) {
+        return ApiResponse.success(SuccessStatus.UPDATED, onboardingService.updateInterestTags(getUserId(jwt), request));
+    }
+
+    @Operation(summary = "온보딩 완료", description = "필수 온보딩 정보가 모두 설정되었는지 검증하고 완료 처리합니다.")
+    @PostMapping("/complete")
+    public ResponseEntity<ApiResponse<OnboardingCompleteResponse>> complete(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return ApiResponse.success(SuccessStatus.UPDATED, onboardingService.complete(getUserId(jwt)));
+    }
+
+    private Long getUserId(Jwt jwt) {
+        return Long.parseLong(jwt.getSubject());
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/domain/InterestTag.java
+++ b/src/main/java/PickitPickit/onboarding/domain/InterestTag.java
@@ -1,0 +1,32 @@
+package PickitPickit.onboarding.domain;
+
+import PickitPickit.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "interest_tags",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_interest_tags_name", columnNames = "name")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private boolean active = true;
+}

--- a/src/main/java/PickitPickit/onboarding/domain/UserInterestTag.java
+++ b/src/main/java/PickitPickit/onboarding/domain/UserInterestTag.java
@@ -1,0 +1,44 @@
+package PickitPickit.onboarding.domain;
+
+import PickitPickit.global.entity.BaseTimeEntity;
+import PickitPickit.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "user_interest_tags",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_interest_tags_user_tag",
+                        columnNames = {"user_id", "interest_tag_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInterestTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "interest_tag_id", nullable = false)
+    private InterestTag interestTag;
+
+    private UserInterestTag(User user, InterestTag interestTag) {
+        this.user = user;
+        this.interestTag = interestTag;
+    }
+
+    public static UserInterestTag create(User user, InterestTag interestTag) {
+        return new UserInterestTag(user, interestTag);
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/dto/request/InterestTagUpdateRequest.java
+++ b/src/main/java/PickitPickit/onboarding/dto/request/InterestTagUpdateRequest.java
@@ -1,0 +1,8 @@
+package PickitPickit.onboarding.dto.request;
+
+import java.util.List;
+
+public record InterestTagUpdateRequest(
+        List<Long> tagIds
+) {
+}

--- a/src/main/java/PickitPickit/onboarding/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/PickitPickit/onboarding/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,6 @@
+package PickitPickit.onboarding.dto.request;
+
+public record NicknameUpdateRequest(
+        String nickname
+) {
+}

--- a/src/main/java/PickitPickit/onboarding/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/PickitPickit/onboarding/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,7 @@
+package PickitPickit.onboarding.dto.request;
+
+public record ProfileImageUpdateRequest(
+        String type,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/PickitPickit/onboarding/dto/response/DefaultProfileImageResponse.java
+++ b/src/main/java/PickitPickit/onboarding/dto/response/DefaultProfileImageResponse.java
@@ -1,0 +1,7 @@
+package PickitPickit.onboarding.dto.response;
+
+public record DefaultProfileImageResponse(
+        String id,
+        String imageUrl
+) {
+}

--- a/src/main/java/PickitPickit/onboarding/dto/response/InterestTagResponse.java
+++ b/src/main/java/PickitPickit/onboarding/dto/response/InterestTagResponse.java
@@ -1,0 +1,13 @@
+package PickitPickit.onboarding.dto.response;
+
+import PickitPickit.onboarding.domain.InterestTag;
+
+public record InterestTagResponse(
+        Long id,
+        String name
+) {
+
+    public static InterestTagResponse from(InterestTag interestTag) {
+        return new InterestTagResponse(interestTag.getId(), interestTag.getName());
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/dto/response/OnboardingCompleteResponse.java
+++ b/src/main/java/PickitPickit/onboarding/dto/response/OnboardingCompleteResponse.java
@@ -1,0 +1,11 @@
+package PickitPickit.onboarding.dto.response;
+
+public record OnboardingCompleteResponse(
+        boolean onboardingCompleted,
+        String next
+) {
+
+    public static OnboardingCompleteResponse mainMap() {
+        return new OnboardingCompleteResponse(true, "MAIN_MAP");
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/dto/response/OnboardingStatusResponse.java
+++ b/src/main/java/PickitPickit/onboarding/dto/response/OnboardingStatusResponse.java
@@ -1,0 +1,37 @@
+package PickitPickit.onboarding.dto.response;
+
+import PickitPickit.onboarding.domain.UserInterestTag;
+import PickitPickit.user.domain.User;
+import PickitPickit.user.domain.ProfileImageType;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record OnboardingStatusResponse(
+        Long userId,
+        String nickname,
+        String profileImageUrl,
+        String kakaoProfileImageUrl,
+        ProfileImageType profileImageType,
+        List<InterestTagResponse> selectedTags,
+        boolean onboardingCompleted
+) {
+
+    public static OnboardingStatusResponse of(User user, List<UserInterestTag> userInterestTags) {
+        List<InterestTagResponse> selectedTags = userInterestTags.stream()
+                .map(UserInterestTag::getInterestTag)
+                .sorted(Comparator.comparingInt(interestTag -> interestTag.getDisplayOrder()))
+                .map(InterestTagResponse::from)
+                .toList();
+
+        return new OnboardingStatusResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.getKakaoProfileImageUrl(),
+                user.getProfileImageType(),
+                selectedTags,
+                user.isOnboardingCompleted()
+        );
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/dto/response/ProfileImageOptionsResponse.java
+++ b/src/main/java/PickitPickit/onboarding/dto/response/ProfileImageOptionsResponse.java
@@ -1,0 +1,9 @@
+package PickitPickit.onboarding.dto.response;
+
+import java.util.List;
+
+public record ProfileImageOptionsResponse(
+        String kakaoProfileImageUrl,
+        List<DefaultProfileImageResponse> defaultImages
+) {
+}

--- a/src/main/java/PickitPickit/onboarding/repository/InterestTagRepository.java
+++ b/src/main/java/PickitPickit/onboarding/repository/InterestTagRepository.java
@@ -1,0 +1,14 @@
+package PickitPickit.onboarding.repository;
+
+import PickitPickit.onboarding.domain.InterestTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface InterestTagRepository extends JpaRepository<InterestTag, Long> {
+
+    List<InterestTag> findByActiveTrueOrderByDisplayOrderAsc();
+
+    List<InterestTag> findByIdInAndActiveTrue(Collection<Long> ids);
+}

--- a/src/main/java/PickitPickit/onboarding/repository/UserInterestTagRepository.java
+++ b/src/main/java/PickitPickit/onboarding/repository/UserInterestTagRepository.java
@@ -1,0 +1,16 @@
+package PickitPickit.onboarding.repository;
+
+import PickitPickit.onboarding.domain.UserInterestTag;
+import PickitPickit.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserInterestTagRepository extends JpaRepository<UserInterestTag, Long> {
+
+    List<UserInterestTag> findByUserId(Long userId);
+
+    void deleteByUser(User user);
+
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/PickitPickit/onboarding/service/DefaultProfileImageCatalog.java
+++ b/src/main/java/PickitPickit/onboarding/service/DefaultProfileImageCatalog.java
@@ -1,0 +1,28 @@
+package PickitPickit.onboarding.service;
+
+import PickitPickit.onboarding.dto.response.DefaultProfileImageResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DefaultProfileImageCatalog {
+
+    private static final List<DefaultProfileImageResponse> DEFAULT_IMAGES = List.of(
+            new DefaultProfileImageResponse("DEFAULT_1", "/images/profile-defaults/default-1.png"),
+            new DefaultProfileImageResponse("DEFAULT_2", "/images/profile-defaults/default-2.png"),
+            new DefaultProfileImageResponse("DEFAULT_3", "/images/profile-defaults/default-3.png"),
+            new DefaultProfileImageResponse("DEFAULT_4", "/images/profile-defaults/default-4.png"),
+            new DefaultProfileImageResponse("DEFAULT_5", "/images/profile-defaults/default-5.png"),
+            new DefaultProfileImageResponse("DEFAULT_6", "/images/profile-defaults/default-6.png")
+    );
+
+    public List<DefaultProfileImageResponse> getDefaultImages() {
+        return DEFAULT_IMAGES;
+    }
+
+    public boolean containsImageUrl(String imageUrl) {
+        return DEFAULT_IMAGES.stream()
+                .anyMatch(defaultImage -> defaultImage.imageUrl().equals(imageUrl));
+    }
+}

--- a/src/main/java/PickitPickit/onboarding/service/OnboardingService.java
+++ b/src/main/java/PickitPickit/onboarding/service/OnboardingService.java
@@ -1,0 +1,173 @@
+package PickitPickit.onboarding.service;
+
+import PickitPickit.global.exception.ApiException;
+import PickitPickit.global.response.ErrorStatus;
+import PickitPickit.onboarding.domain.InterestTag;
+import PickitPickit.onboarding.domain.UserInterestTag;
+import PickitPickit.onboarding.dto.request.InterestTagUpdateRequest;
+import PickitPickit.onboarding.dto.request.NicknameUpdateRequest;
+import PickitPickit.onboarding.dto.request.ProfileImageUpdateRequest;
+import PickitPickit.onboarding.dto.response.*;
+import PickitPickit.onboarding.repository.InterestTagRepository;
+import PickitPickit.onboarding.repository.UserInterestTagRepository;
+import PickitPickit.user.domain.ProfileImageType;
+import PickitPickit.user.domain.User;
+import PickitPickit.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+
+    private static final int NICKNAME_MIN_LENGTH = 2;
+    private static final int NICKNAME_MAX_LENGTH = 15;
+
+    private final UserRepository userRepository;
+    private final InterestTagRepository interestTagRepository;
+    private final UserInterestTagRepository userInterestTagRepository;
+    private final DefaultProfileImageCatalog defaultProfileImageCatalog;
+
+    @Transactional(readOnly = true)
+    public OnboardingStatusResponse getStatus(Long userId) {
+        User user = getUser(userId);
+        return OnboardingStatusResponse.of(user, userInterestTagRepository.findByUserId(userId));
+    }
+
+    @Transactional
+    public OnboardingStatusResponse updateNickname(Long userId, NicknameUpdateRequest request) {
+        User user = getUser(userId);
+        String nickname = normalizeNickname(request == null ? null : request.nickname());
+
+        if (!isValidNickname(nickname)) {
+            throw new ApiException(ErrorStatus.INVALID_NICKNAME);
+        }
+
+        if (userRepository.existsByNicknameAndIdNot(nickname, user.getId())) {
+            throw new ApiException(ErrorStatus.DUPLICATE_NICKNAME);
+        }
+
+        user.updateNickname(nickname);
+        return OnboardingStatusResponse.of(user, userInterestTagRepository.findByUserId(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileImageOptionsResponse getProfileImages(Long userId) {
+        User user = getUser(userId);
+        return new ProfileImageOptionsResponse(
+                user.getKakaoProfileImageUrl(),
+                defaultProfileImageCatalog.getDefaultImages()
+        );
+    }
+
+    @Transactional
+    public OnboardingStatusResponse updateProfileImage(Long userId, ProfileImageUpdateRequest request) {
+        User user = getUser(userId);
+        ProfileImageType type = parseProfileImageType(request == null ? null : request.type());
+        String profileImageUrl = request == null ? null : request.profileImageUrl();
+
+        validateProfileImage(user, type, profileImageUrl);
+        user.updateProfileImage(type, profileImageUrl);
+
+        return OnboardingStatusResponse.of(user, userInterestTagRepository.findByUserId(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<InterestTagResponse> getInterestTags() {
+        return interestTagRepository.findByActiveTrueOrderByDisplayOrderAsc().stream()
+                .map(InterestTagResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public OnboardingStatusResponse updateInterestTags(Long userId, InterestTagUpdateRequest request) {
+        User user = getUser(userId);
+        List<Long> tagIds = request == null ? null : request.tagIds();
+
+        if (tagIds == null || tagIds.isEmpty()) {
+            throw new ApiException(ErrorStatus.INTEREST_TAG_REQUIRED);
+        }
+
+        List<Long> uniqueTagIds = new LinkedHashSet<>(tagIds).stream().toList();
+        List<InterestTag> interestTags = interestTagRepository.findByIdInAndActiveTrue(uniqueTagIds);
+
+        if (interestTags.size() != uniqueTagIds.size()) {
+            throw new ApiException(ErrorStatus.INTEREST_TAG_NOT_FOUND);
+        }
+
+        userInterestTagRepository.deleteByUser(user);
+        userInterestTagRepository.saveAll(
+                interestTags.stream()
+                        .map(interestTag -> UserInterestTag.create(user, interestTag))
+                        .toList()
+        );
+        user.markOnboardingIncomplete();
+
+        return OnboardingStatusResponse.of(user, userInterestTagRepository.findByUserId(userId));
+    }
+
+    @Transactional
+    public OnboardingCompleteResponse complete(Long userId) {
+        User user = getUser(userId);
+
+        if (!isValidNickname(user.getNickname())
+                || !StringUtils.hasText(user.getProfileImageUrl())
+                || !userInterestTagRepository.existsByUserId(userId)) {
+            throw new ApiException(ErrorStatus.ONBOARDING_INCOMPLETE);
+        }
+
+        user.completeOnboarding();
+        return OnboardingCompleteResponse.mainMap();
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND, "해당 사용자를 찾을 수 없습니다."));
+    }
+
+    private String normalizeNickname(String nickname) {
+        return nickname == null ? null : nickname.trim();
+    }
+
+    private boolean isValidNickname(String nickname) {
+        return StringUtils.hasText(nickname)
+                && nickname.length() >= NICKNAME_MIN_LENGTH
+                && nickname.length() <= NICKNAME_MAX_LENGTH;
+    }
+
+    private ProfileImageType parseProfileImageType(String type) {
+        if (!StringUtils.hasText(type)) {
+            throw new ApiException(ErrorStatus.INVALID_PROFILE_IMAGE_TYPE);
+        }
+
+        try {
+            return ProfileImageType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorStatus.INVALID_PROFILE_IMAGE_TYPE);
+        }
+    }
+
+    private void validateProfileImage(User user, ProfileImageType type, String profileImageUrl) {
+        if (!StringUtils.hasText(profileImageUrl)) {
+            throw new ApiException(ErrorStatus.INVALID_PROFILE_IMAGE);
+        }
+
+        if (type == ProfileImageType.KAKAO) {
+            if (!profileImageUrl.equals(user.getKakaoProfileImageUrl())) {
+                throw new ApiException(ErrorStatus.INVALID_PROFILE_IMAGE);
+            }
+            return;
+        }
+
+        if (type == ProfileImageType.DEFAULT && defaultProfileImageCatalog.containsImageUrl(profileImageUrl)) {
+            return;
+        }
+
+        throw new ApiException(ErrorStatus.INVALID_PROFILE_IMAGE);
+    }
+}

--- a/src/main/java/PickitPickit/user/domain/ProfileImageType.java
+++ b/src/main/java/PickitPickit/user/domain/ProfileImageType.java
@@ -1,0 +1,6 @@
+package PickitPickit.user.domain;
+
+public enum ProfileImageType {
+    KAKAO,
+    DEFAULT
+}

--- a/src/main/java/PickitPickit/user/domain/User.java
+++ b/src/main/java/PickitPickit/user/domain/User.java
@@ -15,6 +15,10 @@ import lombok.NoArgsConstructor;
                 @UniqueConstraint(
                         name = "uq_users_kakao_id",
                         columnNames = "kakao_id"
+                ),
+                @UniqueConstraint(
+                        name = "uq_users_nickname",
+                        columnNames = "nickname"
                 )
         }
 )
@@ -34,23 +38,63 @@ public class User extends BaseTimeEntity {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
+    @Column(name = "kakao_profile_image_url", length = 500)
+    private String kakaoProfileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "profile_image_type", length = 20)
+    private ProfileImageType profileImageType;
+
+    @Column(name = "onboarding_completed", nullable = false)
+    private boolean onboardingCompleted;
+
     @Builder
-    private User(String kakaoId, String nickname, String profileImageUrl) {
+    private User(String kakaoId, String nickname, String profileImageUrl,
+                 String kakaoProfileImageUrl, ProfileImageType profileImageType,
+                 boolean onboardingCompleted) {
         this.kakaoId = kakaoId;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.kakaoProfileImageUrl = kakaoProfileImageUrl;
+        this.profileImageType = profileImageType;
+        this.onboardingCompleted = onboardingCompleted;
     }
 
     public static User createFromKakao(String kakaoId, String nickname, String profileImageUrl) {
+        ProfileImageType profileImageType = profileImageUrl != null && !profileImageUrl.isBlank()
+                ? ProfileImageType.KAKAO
+                : null;
+
         return User.builder()
                 .kakaoId(kakaoId)
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
+                .kakaoProfileImageUrl(profileImageUrl)
+                .profileImageType(profileImageType)
+                .onboardingCompleted(false)
                 .build();
     }
 
-    public void updateProfile(String nickname, String profileImageUrl) {
+    public void updateKakaoProfileImageUrl(String kakaoProfileImageUrl) {
+        this.kakaoProfileImageUrl = kakaoProfileImageUrl;
+    }
+
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
+        this.onboardingCompleted = false;
+    }
+
+    public void updateProfileImage(ProfileImageType profileImageType, String profileImageUrl) {
+        this.profileImageType = profileImageType;
         this.profileImageUrl = profileImageUrl;
+        this.onboardingCompleted = false;
+    }
+
+    public void markOnboardingIncomplete() {
+        this.onboardingCompleted = false;
+    }
+
+    public void completeOnboarding() {
+        this.onboardingCompleted = true;
     }
 }

--- a/src/main/java/PickitPickit/user/repository/UserRepository.java
+++ b/src/main/java/PickitPickit/user/repository/UserRepository.java
@@ -8,4 +8,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByKakaoId(String kakaoId);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/resources/db/migration/V8__add_user_onboarding_fields.sql
+++ b/src/main/resources/db/migration/V8__add_user_onboarding_fields.sql
@@ -1,0 +1,29 @@
+alter table users
+    add column kakao_profile_image_url varchar(500),
+    add column profile_image_type varchar(20),
+    add column onboarding_completed boolean not null default false;
+
+update users
+set kakao_profile_image_url = profile_image_url
+where kakao_profile_image_url is null
+  and profile_image_url is not null;
+
+update users
+set profile_image_type = 'KAKAO'
+where profile_image_url is not null
+  and profile_image_type is null;
+
+with duplicated_users as (
+    select id,
+           row_number() over (partition by nickname order by id) as rn
+    from users
+)
+update users u
+set nickname = 'pickit_' || u.id
+from duplicated_users d
+where u.id = d.id
+  and d.rn > 1;
+
+alter table users
+    add constraint uq_users_nickname unique (nickname);
+

--- a/src/main/resources/db/migration/V9__add_interest_tags.sql
+++ b/src/main/resources/db/migration/V9__add_interest_tags.sql
@@ -1,0 +1,43 @@
+create table interest_tags (
+    id bigserial primary key,
+    name varchar(50) not null,
+    display_order integer not null,
+    active boolean not null default true,
+    created_at timestamp not null default current_timestamp,
+    modified_at timestamp not null default current_timestamp,
+
+    constraint uq_interest_tags_name unique (name)
+);
+
+create table user_interest_tags (
+    id bigserial primary key,
+    user_id bigint not null,
+    interest_tag_id bigint not null,
+    created_at timestamp not null default current_timestamp,
+    modified_at timestamp not null default current_timestamp,
+
+    constraint fk_user_interest_tags_user foreign key (user_id) references users (id) on delete cascade,
+    constraint fk_user_interest_tags_interest_tag foreign key (interest_tag_id) references interest_tags (id) on delete cascade,
+    constraint uq_user_interest_tags_user_tag unique (user_id, interest_tag_id)
+);
+
+create index idx_interest_tags_active_order on interest_tags (active, display_order);
+create index idx_user_interest_tags_user_id on user_interest_tags (user_id);
+
+insert into interest_tags (name, display_order)
+values
+    ('포켓몬', 1),
+    ('디즈니', 2),
+    ('원피스', 3),
+    ('산리오', 4),
+    ('마블', 5),
+    ('BT21', 6),
+    ('짱구', 7),
+    ('팬텀', 8),
+    ('귀멸의칼날', 9),
+    ('나루토', 10),
+    ('카카오', 11),
+    ('지브리', 12),
+    ('메이플', 13),
+    ('스누피', 14),
+    ('드래곤볼', 15);

--- a/src/test/java/PickitPickit/auth/service/AuthServiceTest.java
+++ b/src/test/java/PickitPickit/auth/service/AuthServiceTest.java
@@ -8,9 +8,9 @@ import PickitPickit.auth.dto.request.LogoutRequest;
 import PickitPickit.auth.dto.request.RefreshTokenRequest;
 import PickitPickit.auth.dto.response.LoginResponse;
 import PickitPickit.auth.dto.response.TokenResponse;
-import PickitPickit.global.exception.ApiException;
 import PickitPickit.global.security.JwtTokenProvider;
 import PickitPickit.global.security.TokenPair;
+import PickitPickit.user.domain.ProfileImageType;
 import PickitPickit.user.domain.User;
 import PickitPickit.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +26,6 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -66,6 +65,7 @@ class AuthServiceTest {
 
         when(kakaoAuthClient.getUserInfo(KAKAO_ACCESS_TOKEN)).thenReturn(kakaoUser);
         when(userRepository.findByKakaoId("12345")).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname("민수")).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
             User user = invocation.getArgument(0);
             ReflectionTestUtils.setField(user, "id", 1L);
@@ -80,6 +80,7 @@ class AuthServiceTest {
         assertThat(response.user().id()).isEqualTo(1L);
         assertThat(response.user().nickname()).isEqualTo("민수");
         assertThat(response.user().profileImageUrl()).isNull();
+        assertThat(response.user().onboardingCompleted()).isFalse();
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
@@ -89,9 +90,11 @@ class AuthServiceTest {
     }
 
     @Test
-    void loginWithKakaoReusesExistingUserAndUpdatesProfile() {
+    void loginWithKakaoReusesExistingUserWithoutOverwritingOnboardingProfile() {
         User existingUser = User.createFromKakao("12345", "예전닉네임", "old-image");
         ReflectionTestUtils.setField(existingUser, "id", 1L);
+        existingUser.updateNickname("커스텀닉네임");
+        existingUser.updateProfileImage(ProfileImageType.DEFAULT, "/images/profile-defaults/default-1.png");
 
         when(kakaoAuthClient.getUserInfo(KAKAO_ACCESS_TOKEN))
                 .thenReturn(kakaoUser(12345L, "새닉네임", "new-image"));
@@ -100,24 +103,30 @@ class AuthServiceTest {
 
         LoginResponse response = authService.loginWithKakao(new KakaoLoginRequest(KAKAO_ACCESS_TOKEN));
 
-        assertThat(response.user().nickname()).isEqualTo("새닉네임");
-        assertThat(response.user().profileImageUrl()).isEqualTo("new-image");
-        assertThat(existingUser.getNickname()).isEqualTo("새닉네임");
-        assertThat(existingUser.getProfileImageUrl()).isEqualTo("new-image");
+        assertThat(response.user().nickname()).isEqualTo("커스텀닉네임");
+        assertThat(response.user().profileImageUrl()).isEqualTo("/images/profile-defaults/default-1.png");
+        assertThat(existingUser.getNickname()).isEqualTo("커스텀닉네임");
+        assertThat(existingUser.getProfileImageUrl()).isEqualTo("/images/profile-defaults/default-1.png");
+        assertThat(existingUser.getKakaoProfileImageUrl()).isEqualTo("new-image");
         verify(userRepository, never()).save(any(User.class));
     }
 
     @Test
-    void loginWithKakaoFailsWhenNicknameIsMissing() {
+    void loginWithKakaoCreatesTemporaryNicknameWhenKakaoNicknameIsMissing() {
         when(kakaoAuthClient.getUserInfo(KAKAO_ACCESS_TOKEN))
                 .thenReturn(kakaoUser(12345L, null, null));
+        when(userRepository.findByKakaoId("12345")).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname("pickit_12345")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", 1L);
+            return user;
+        });
+        when(jwtTokenProvider.createTokenPair(1L)).thenReturn(tokenPair());
 
-        assertThatThrownBy(() -> authService.loginWithKakao(new KakaoLoginRequest(KAKAO_ACCESS_TOKEN)))
-                .isInstanceOf(ApiException.class)
-                .hasMessage("카카오 닉네임 동의가 필요합니다.");
+        LoginResponse response = authService.loginWithKakao(new KakaoLoginRequest(KAKAO_ACCESS_TOKEN));
 
-        verify(userRepository, never()).save(any(User.class));
-        verify(jwtTokenProvider, never()).createTokenPair(any());
+        assertThat(response.user().nickname()).isEqualTo("pickit_12345");
     }
 
     @Test

--- a/src/test/java/PickitPickit/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/PickitPickit/onboarding/service/OnboardingServiceTest.java
@@ -1,0 +1,192 @@
+package PickitPickit.onboarding.service;
+
+import PickitPickit.global.exception.ApiException;
+import PickitPickit.global.response.ErrorStatus;
+import PickitPickit.onboarding.domain.InterestTag;
+import PickitPickit.onboarding.dto.request.InterestTagUpdateRequest;
+import PickitPickit.onboarding.dto.request.NicknameUpdateRequest;
+import PickitPickit.onboarding.dto.request.ProfileImageUpdateRequest;
+import PickitPickit.onboarding.repository.InterestTagRepository;
+import PickitPickit.onboarding.repository.UserInterestTagRepository;
+import PickitPickit.user.domain.ProfileImageType;
+import PickitPickit.user.domain.User;
+import PickitPickit.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private InterestTagRepository interestTagRepository;
+
+    @Mock
+    private UserInterestTagRepository userInterestTagRepository;
+
+    private OnboardingService onboardingService;
+
+    @BeforeEach
+    void setUp() {
+        onboardingService = new OnboardingService(
+                userRepository,
+                interestTagRepository,
+                userInterestTagRepository,
+                new DefaultProfileImageCatalog()
+        );
+    }
+
+    @Test
+    void updateNicknameSavesTrimmedNickname() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNicknameAndIdNot("새닉네임", 1L)).thenReturn(false);
+        when(userInterestTagRepository.findByUserId(1L)).thenReturn(List.of());
+
+        onboardingService.updateNickname(1L, new NicknameUpdateRequest(" 새닉네임 "));
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+    }
+
+    @Test
+    void updateNicknameFailsWhenNicknameIsInvalid() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> onboardingService.updateNickname(1L, new NicknameUpdateRequest("a")))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.INVALID_NICKNAME));
+    }
+
+    @Test
+    void updateNicknameFailsWhenNicknameIsDuplicated() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNicknameAndIdNot("중복닉네임", 1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> onboardingService.updateNickname(1L, new NicknameUpdateRequest("중복닉네임")))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.DUPLICATE_NICKNAME));
+    }
+
+    @Test
+    void updateProfileImageSavesDefaultImageWhenUrlIsAllowed() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userInterestTagRepository.findByUserId(1L)).thenReturn(List.of());
+
+        onboardingService.updateProfileImage(
+                1L,
+                new ProfileImageUpdateRequest("DEFAULT", "/images/profile-defaults/default-1.png")
+        );
+
+        assertThat(user.getProfileImageType()).isEqualTo(ProfileImageType.DEFAULT);
+        assertThat(user.getProfileImageUrl()).isEqualTo("/images/profile-defaults/default-1.png");
+    }
+
+    @Test
+    void updateProfileImageFailsWhenUrlIsNotAllowed() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> onboardingService.updateProfileImage(
+                1L,
+                new ProfileImageUpdateRequest("DEFAULT", "https://evil.example/profile.png")
+        ))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.INVALID_PROFILE_IMAGE));
+    }
+
+    @Test
+    void updateProfileImageSavesKakaoImageWhenUrlMatches() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userInterestTagRepository.findByUserId(1L)).thenReturn(List.of());
+
+        onboardingService.updateProfileImage(
+                1L,
+                new ProfileImageUpdateRequest("KAKAO", "kakao-image")
+        );
+
+        assertThat(user.getProfileImageType()).isEqualTo(ProfileImageType.KAKAO);
+        assertThat(user.getProfileImageUrl()).isEqualTo("kakao-image");
+    }
+
+    @Test
+    void updateInterestTagsFailsWhenEmpty() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> onboardingService.updateInterestTags(1L, new InterestTagUpdateRequest(List.of())))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.INTEREST_TAG_REQUIRED));
+    }
+
+    @Test
+    void updateInterestTagsFailsWhenTagDoesNotExist() {
+        User user = user();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(interestTagRepository.findByIdInAndActiveTrue(List.of(1L, 99L))).thenReturn(List.of(interestTag(1L)));
+
+        assertThatThrownBy(() -> onboardingService.updateInterestTags(1L, new InterestTagUpdateRequest(List.of(1L, 99L))))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.INTEREST_TAG_NOT_FOUND));
+    }
+
+    @Test
+    void completeSucceedsWhenRequiredFieldsExist() {
+        User user = user();
+        user.updateProfileImage(ProfileImageType.DEFAULT, "/images/profile-defaults/default-1.png");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userInterestTagRepository.existsByUserId(1L)).thenReturn(true);
+
+        assertThat(onboardingService.complete(1L).next()).isEqualTo("MAIN_MAP");
+        assertThat(user.isOnboardingCompleted()).isTrue();
+    }
+
+    @Test
+    void completeFailsWhenTagIsMissing() {
+        User user = user();
+        user.updateProfileImage(ProfileImageType.DEFAULT, "/images/profile-defaults/default-1.png");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userInterestTagRepository.existsByUserId(1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> onboardingService.complete(1L))
+                .isInstanceOfSatisfying(ApiException.class,
+                        exception -> assertThat(exception.getErrorStatus()).isEqualTo(ErrorStatus.ONBOARDING_INCOMPLETE));
+    }
+
+    private User user() {
+        User user = User.createFromKakao("12345", "민수", "kakao-image");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private InterestTag interestTag(Long id) {
+        try {
+            var constructor = InterestTag.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            InterestTag interestTag = constructor.newInstance();
+            ReflectionTestUtils.setField(interestTag, "id", id);
+            ReflectionTestUtils.setField(interestTag, "name", "포켓몬");
+            ReflectionTestUtils.setField(interestTag, "displayOrder", 1);
+            ReflectionTestUtils.setField(interestTag, "active", true);
+            return interestTag;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 카카오 로그인 응답과 사용자 정보에 온보딩 완료 상태를 추가했습니다.
- 초기 온보딩 API를 추가했습니다: 상태 조회, 닉네임 저장, 프로필 이미지 후보/저장, 관심 태그 조회/저장, 완료 처리.
- 닉네임 2~15자 및 중복 검증, 프로필 이미지 허용 URL 검증, 관심 태그 최소 1개 검증을 추가했습니다.
- 온보딩 전용 에러 코드와 Spring Security 인증/인가 실패 JSON 응답을 추가했습니다.
- 관심 태그 및 사용자 관심 태그 Flyway migration과 seed 데이터를 추가했습니다.

## ➕ 이슈 링크
* Closes #14

## 🧪 테스트 방법
- ./gradlew clean build

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [ ] 주요 기능 수동 테스트 완료
- [x] 예외/실패 응답 형식 일관성 확인

## 📸 스크린샷 (선택)
-