### PR TITLE
[CHORE] PR 빌드 CI 추가(#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build
+        run: ./gradlew clean build


### PR DESCRIPTION
## 🔎 작업 내용
- PR 대상 dev 브랜치에 대해 clean build를 수행하는 CI workflow를 추가했습니다.
- 수동 실행(workflow_dispatch)을 지원합니다.
- Java 21 Temurin과 Gradle cache를 사용합니다.
- 기존 Deploy to EC2 workflow는 변경하지 않았습니다.

## ➕ 이슈 링크
* Closes #16

## 🧪 테스트 방법
- ./gradlew clean build

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [ ] GitHub Actions CI 실행 확인

## 📸 스크린샷 (선택)
-